### PR TITLE
Currency - override hashcode

### DIFF
--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -39,6 +39,9 @@ class Currency(object):
     def __repr__(self):
         return self.code
 
+    def __hash__(self):
+        return hash(self.code)
+
 
 class MoneyComparisonError(TypeError):
     # This exception was needed often enough to merit its own

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -62,6 +62,13 @@ class TestCurrency:
         assert self.default_curr == 'XYZ'
         assert self.default_curr != 'USD'
 
+    def test_use_currency_in_dict(self):
+        data = {
+            'USD': 123
+        }
+        assert CURRENCIES['USD'] in data
+        assert data[CURRENCIES['USD']] == 123
+
     def test_fetching_currency_by_iso_code(self):
         assert get_currency('USD') == USD
         assert get_currency(iso='840') == USD


### PR DESCRIPTION
I should have done this when I changed the equality operator to allow
comparisons to strings. Before this change, you could do `currencies.USD
== 'USD'`, but not `currencies.USD in {'USD': 123}`.

Gotta obey the contract of equals and hashcode.
