### PR TITLE
Money - implement hash code

### DIFF
--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -184,6 +184,9 @@ class Money(object):
         result = self.__eq__(other)
         return not result
 
+    def __hash__(self):
+        return hash((self.amount, self.currency))
+
     def __lt__(self, other):
         if not isinstance(other, Money):
             raise MoneyComparisonError(other)

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -198,6 +198,13 @@ class TestMoney:
             assert (self.one_million_bucks % self.one_million_bucks
                     == 1)
 
+    def test_hash(self):
+        instance1 = Money(amount=10, currency=self.USD)
+        instance2 = Money(amount=10, currency=self.USD)
+        assert hash(instance1) == hash(instance2)
+        assert hash(instance1) != hash(Money(11, currency=self.USD))
+        assert hash(instance1) != hash(Money(10, currency=CURRENCIES['CAD']))
+
     def test_rmod_float_warning(self):
         # This should be changed to TypeError exception after deprecation period is over.
         with warnings.catch_warnings(record=True) as warning_list:


### PR DESCRIPTION
Money overrides equals but not hashcode. I was using Money instances as
keys in a dict and got confused as to why it wasn't working.
