### PR TITLE
Upgrade Version - updated files to represent the updated py-moneyed r…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ downloads
 eggs
 parts
 src/*.egg-info
+*.egg-info
 build/
 .ropeproject
 .tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,6 @@
 include README.rst
+include CHANGES.rst
+include CONTRIBUTORS
+include LICENSE
+include RELEASE.rst
+include tox.ini

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,11 @@
+.. image:: https://travis-ci.org/limist/py-moneyed.svg?branch=master
+    :target: https://travis-ci.org/limist/py-moneyed
+    :alt: Build Status
+
+.. image:: https://badge.fury.io/py/py-moneyed.svg
+    :target: https://badge.fury.io/py/py-moneyed
+    :alt: Latest PyPI version
+
 Overview
 ========
 
@@ -23,28 +31,69 @@ Usage
 
 On to the code! The Money class is instantiated with:
 
-- An amount which can be of type string, float, or Decimal.  
+- An amount which can be of type int, string, float, or Decimal.
+  It will be converted to a Decimal internally. Therefore, it is best
+  to avoid float objects, since they do not convert losslessly
+  to Decimal.
+
 - A currency, which usually is specified by the three-capital-letters
   ISO currency code, e.g. USD, EUR, CNY, and so on.
+  It will be converted to a Currency object.
 
 For example,
 
 .. sourcecode:: python
 
-    from moneyed.classes import Money
+    from moneyed import Money
     sale_price_today = Money(amount='99.99', currency='USD')
 
-The Money class also provides operators with type checking, matching
-currency checking, and sensible dimensional behavior, e.g. you cannot
-multiply two Money instances, nor can you add a Money instance to a
-non-Money number; dividing a Money instance by another results in a
-Decimal value, etc.
+
+You then use Money instances as a normal number. The Money class provides
+operators with type checking, matching currency checking, and sensible
+dimensional behavior, e.g. you cannot multiply two Money instances, nor can you
+add a Money instance to a non-Money number; dividing a Money instance by another
+results in a Decimal value, etc.
 
 The Currency class is provided with a complete dictionary of ISO 4217
 currencies data, each key (e.g. 'USD') mapping to a Currency instance
 with ISO numeric code, canonical name in English, and countries using
 the currency.  Thanks to the python-money developers for their
 (possibly tedious) data-entry of the ISO codes!
+
+All of these are available as pre-built Currency objects in the `moneyed`
+module.
+
+You can also pass in the arguments to Money as positional arguments.
+So you can also write:
+
+.. sourcecode:: python
+
+    >>> from moneyed import Money, USD
+    >>> price = Money('19.50', USD)
+    >>> price
+    19 USD
+
+    >>> price.amount
+    Decimal('19.50')
+
+    >>> price.currency
+    USD
+
+    >>> price.currency.code
+    'USD'
+
+
+Formatting
+----------
+
+You can print Money object as follows:
+
+.. sourcecode:: python
+
+   >>> from moneyed.localization import format_money
+   >>> format_money(Money(10, USD), locale='en_US')
+   '$10.00'
+
 
 Testing
 -------
@@ -57,7 +106,7 @@ tool to automate running tests and deployment; install it to your
 global Python environment with: ::
 
     sudo pip install tox
-    
+
 Then you can activate a virtualenv (any will do - by design tox will
 not run from your globally-installed python), cd to the py-moneyed
 source directory then run the tests at the shell: ::
@@ -69,8 +118,8 @@ If you do not have all versions of Python that are used in testing,
 you can use pyenv_. After installing pyenv, install the additional
 plugin pyenv-implict_.
 
-The py-moneyed package has been tested with Python 2.6, 2.7, 3.2, 3.3 
-and PyPy 2.1.
+The py-moneyed package is tested against Python 2.6, 2.7, 3.2, 3.3,
+3.4, 3.5, and PyPy 2.1.
 
 .. _tox: http://tox.testrun.org/latest/
 .. _pyenv: https://github.com/yyuu/pyenv

--- a/moneyed/__init__.py
+++ b/moneyed/__init__.py
@@ -1,1 +1,1 @@
-from .classes import *
+from .classes import *  # NOQA

--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from decimal import Decimal, ROUND_HALF_EVEN
 import moneyed
 
-DEFAULT = "default"
+DEFAULT = "DEFAULT"
 
 
 class CurrencyFormatter(object):
@@ -15,7 +15,7 @@ class CurrencyFormatter(object):
     def add_sign_definition(self, locale, currency, prefix='', suffix=''):
         locale = locale.upper()
         currency_code = currency.code.upper()
-        if not locale in self.sign_definitions:
+        if locale not in self.sign_definitions:
             self.sign_definitions[locale] = {}
         self.sign_definitions[locale][currency_code] = (prefix, suffix)
 
@@ -49,11 +49,9 @@ class CurrencyFormatter(object):
             return ('', " %s" % currency_code)
 
     def get_formatting_definition(self, locale):
-        locale = locale.upper()
-        if locale in self.formatting_definitions:
-            return self.formatting_definitions.get(locale)
-        else:
-            return self.formatting_definitions.get(DEFAULT)
+        if locale.upper() not in self.formatting_definitions:
+            locale = DEFAULT
+        return self.formatting_definitions.get(locale.upper())
 
     def format(self, money, include_symbol=True, locale=DEFAULT,
                decimal_places=None, rounding_method=None):
@@ -121,6 +119,7 @@ class CurrencyFormatter(object):
 
         return ''.join(reversed(result))
 
+
 _FORMATTER = CurrencyFormatter()
 
 format_money = _FORMATTER.format
@@ -128,44 +127,69 @@ format_money = _FORMATTER.format
 _sign = _FORMATTER.add_sign_definition
 _format = _FORMATTER.add_formatting_definition
 
-## FORMATTING RULES
+# FORMATTING RULES
 
 _format(DEFAULT, group_size=3, group_separator=",", decimal_point=".",
-                 positive_sign="", trailing_positive_sign="",
-                 negative_sign="-", trailing_negative_sign="",
-                 rounding_method=ROUND_HALF_EVEN)
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
 
 _format("en_US", group_size=3, group_separator=",", decimal_point=".",
-                 positive_sign="", trailing_positive_sign="",
-                 negative_sign="-", trailing_negative_sign="",
-                 rounding_method=ROUND_HALF_EVEN)
-                 
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
 _format("de_DE", group_size=3, group_separator=" ", decimal_point=",",
-                 positive_sign="", trailing_positive_sign="",
-                 negative_sign="-", trailing_negative_sign="",
-                 rounding_method=ROUND_HALF_EVEN)
-                 
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
 _format("de_AT", group_size=3, group_separator=" ", decimal_point=",",
-                 positive_sign="", trailing_positive_sign="",
-                 negative_sign="-", trailing_negative_sign="",
-                 rounding_method=ROUND_HALF_EVEN)
-                 
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
 _format("de_CH", group_size=3, group_separator=" ", decimal_point=".",
-                 positive_sign="", trailing_positive_sign="",
-                 negative_sign="-", trailing_negative_sign="",
-                 rounding_method=ROUND_HALF_EVEN)
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
+_format("fr_FR", group_size=3, group_separator=" ", decimal_point=",",
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
+_format("fr_CA", group_size=3, group_separator=" ", decimal_point=",",
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
 
 _format("sv_SE", group_size=3, group_separator=" ", decimal_point=",",
-                 positive_sign="", trailing_positive_sign="",
-                 negative_sign="-", trailing_negative_sign="",
-                 rounding_method=ROUND_HALF_EVEN)
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
 
 _format("pl_PL", group_size=3, group_separator=" ", decimal_point=",",
-                 positive_sign="", trailing_positive_sign="",
-                 negative_sign="-", trailing_negative_sign="",
-                 rounding_method=ROUND_HALF_EVEN)
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
 
-## CURRENCY SIGNS
+_format("en_GB", group_size=3, group_separator=",", decimal_point=".",
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
+_format('es_BO', group_size=3, group_separator=".", decimal_point=",",
+        positive_sign="",  trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
+_format("nl_NL", group_size=3, group_separator=".", decimal_point=",",
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
+# CURRENCY SIGNS
 # Default currency signs. These can be overridden for locales where
 # foreign or local currency signs for one reason or another differ
 # from the norm.
@@ -191,18 +215,25 @@ _sign(DEFAULT, moneyed.BHD, prefix='.د.ب')
 _sign(DEFAULT, moneyed.BIF, prefix='FBu')
 _sign(DEFAULT, moneyed.BMD, prefix='BD$')
 _sign(DEFAULT, moneyed.BND, prefix='B$')
+_sign(DEFAULT, moneyed.BOB, prefix='Bs.')
+_sign(DEFAULT, moneyed.BOV, prefix='Bs.')
 _sign(DEFAULT, moneyed.BRL, prefix='R$')
 _sign(DEFAULT, moneyed.BSD, prefix='B$')
 _sign(DEFAULT, moneyed.BTN, prefix='Nu.')
 _sign(DEFAULT, moneyed.BWP, prefix='P')
+_sign(DEFAULT, moneyed.BYN, prefix='Br')
 _sign(DEFAULT, moneyed.BYR, prefix='Br')
 _sign(DEFAULT, moneyed.BZD, prefix='BZ$')
 _sign(DEFAULT, moneyed.CAD, prefix='C$')
 _sign(DEFAULT, moneyed.CDF, prefix='C₣')
+_sign(DEFAULT, moneyed.CHE, prefix='CHE')
 _sign(DEFAULT, moneyed.CHF, prefix='Fr.')
+_sign(DEFAULT, moneyed.CHW, prefix='CHW')
+_sign(DEFAULT, moneyed.CLF, prefix='UF')
 _sign(DEFAULT, moneyed.CLP, prefix='CLP$')
 _sign(DEFAULT, moneyed.CNY, prefix='¥')
 _sign(DEFAULT, moneyed.COP, prefix='COL$')
+_sign(DEFAULT, moneyed.COU, prefix='COU')
 _sign(DEFAULT, moneyed.CRC, prefix='₡')
 _sign(DEFAULT, moneyed.CUC, prefix='CUC$')
 _sign(DEFAULT, moneyed.CUP, prefix='$MN')
@@ -268,6 +299,7 @@ _sign(DEFAULT, moneyed.MUR, prefix='₨')
 _sign(DEFAULT, moneyed.MVR, prefix='Rf.')
 _sign(DEFAULT, moneyed.MWK, prefix='MK')
 _sign(DEFAULT, moneyed.MXN, prefix='Mex$')
+_sign(DEFAULT, moneyed.MXV, prefix='UDI')
 _sign(DEFAULT, moneyed.MYR, prefix='RM')
 _sign(DEFAULT, moneyed.MZN, prefix='MT')
 _sign(DEFAULT, moneyed.NAD, prefix='N$')
@@ -277,6 +309,7 @@ _sign(DEFAULT, moneyed.NOK, suffix=' Nkr')
 _sign(DEFAULT, moneyed.NPR, prefix='₨')
 _sign(DEFAULT, moneyed.NZD, prefix='NZ$')
 _sign(DEFAULT, moneyed.OMR, prefix='ر.ع.')
+_sign(DEFAULT, moneyed.PAB, prefix='B/.')
 _sign(DEFAULT, moneyed.PEN, prefix='S/.')
 _sign(DEFAULT, moneyed.PGK, prefix='K')
 _sign(DEFAULT, moneyed.PHP, prefix='₱')
@@ -285,7 +318,7 @@ _sign(DEFAULT, moneyed.PLN, suffix=' zł')
 _sign(DEFAULT, moneyed.PYG, prefix='₲')
 _sign(DEFAULT, moneyed.QAR, prefix='ر.ق')
 _sign(DEFAULT, moneyed.RSD, prefix='RSD ')
-_sign(DEFAULT, moneyed.RUB, prefix='руб.')
+_sign(DEFAULT, moneyed.RUB, suffix=' руб.')
 _sign(DEFAULT, moneyed.RWF, prefix='FRw')
 _sign(DEFAULT, moneyed.SAR, prefix='ر.س')
 _sign(DEFAULT, moneyed.SBD, prefix='SI$')
@@ -297,11 +330,14 @@ _sign(DEFAULT, moneyed.SHP, prefix='SH£')
 _sign(DEFAULT, moneyed.SLL, prefix='Le')
 _sign(DEFAULT, moneyed.SOS, prefix='Sh.So.')
 _sign(DEFAULT, moneyed.SRD, prefix='SRD$')
+_sign(DEFAULT, moneyed.SSP, prefix='£')
 _sign(DEFAULT, moneyed.STD, prefix='Db')
+_sign(DEFAULT, moneyed.SVC, prefix='₡')
 _sign(DEFAULT, moneyed.SYP, prefix='£S')
 _sign(DEFAULT, moneyed.SZL, prefix='E')
 _sign(DEFAULT, moneyed.THB, prefix='฿')
 _sign(DEFAULT, moneyed.TND, prefix='د.ت')
+_sign(DEFAULT, moneyed.TMT, prefix='m')
 _sign(DEFAULT, moneyed.TOP, prefix='TOP$')
 _sign(DEFAULT, moneyed.TRY, prefix='₺')
 _sign(DEFAULT, moneyed.TTD, prefix='TT$')
@@ -310,6 +346,8 @@ _sign(DEFAULT, moneyed.TWD, prefix='NT$')
 _sign(DEFAULT, moneyed.UAH, prefix='₴')
 _sign(DEFAULT, moneyed.UGX, prefix='USh')
 _sign(DEFAULT, moneyed.USD, prefix='US$')
+_sign(DEFAULT, moneyed.USN, prefix='USN')
+_sign(DEFAULT, moneyed.UYI, prefix='$U')
 _sign(DEFAULT, moneyed.UYU, prefix='$U')
 _sign(DEFAULT, moneyed.VEF, prefix='Bs.')
 _sign(DEFAULT, moneyed.VND, prefix='₫')
@@ -319,17 +357,28 @@ _sign(DEFAULT, moneyed.XAF, prefix='FCFA')
 _sign(DEFAULT, moneyed.XCD, prefix='EC$')
 _sign(DEFAULT, moneyed.XDR, prefix='SDR')
 _sign(DEFAULT, moneyed.XOF, prefix='CFA')
+_sign(DEFAULT, moneyed.XSU, prefix='Sucre')
+_sign(DEFAULT, moneyed.XUA, prefix='XUA')
+_sign(DEFAULT, moneyed.XXX, prefix='XXX')
 _sign(DEFAULT, moneyed.ZAR, prefix='R')
 _sign(DEFAULT, moneyed.ZMK, prefix='ZK')
+_sign(DEFAULT, moneyed.ZMW, prefix='ZK')
 _sign(DEFAULT, moneyed.ZWL, prefix='Z$')
 
 _sign('en_US', moneyed.USD, prefix='$')
-_sign('en_UK', moneyed.GBP, prefix='£')
+_sign('en_GB', moneyed.GBP, prefix='£')
 _sign('sv_SE', moneyed.SEK, prefix=' kr')
 _sign('pl_PL', moneyed.PLN, suffix=' zł')
 _sign('de_DE', moneyed.EUR, suffix=' €')
 _sign('de_AT', moneyed.EUR, suffix=' €')
 _sign('de_CH', moneyed.CHF, prefix='Fr.')
+_sign('fr_FR', moneyed.EUR, suffix=' €')
+_sign('fr_FR', moneyed.USD, suffix=' $ US')
+_sign('fr_CA', moneyed.USD, suffix=' $ US')
+_sign('fr_FR', moneyed.CAD, suffix=' $ CA')
+_sign('fr_CA', moneyed.CAD, suffix=' $')
+_sign('fr_CA', moneyed.EUR, suffix=' €')
+_sign('nl_NL', moneyed.EUR, prefix='€ ')
 
 # Adding translations for missing currencies
 _sign('en_US', moneyed.KWD, prefix='KD')
@@ -341,4 +390,3 @@ _sign('en_US', moneyed.TND, prefix='DT')
 _sign('en_US', moneyed.AED, prefix='Dhs')
 _sign('en_US', moneyed.EGP, prefix='L.E.')
 _sign('en_US', moneyed.QAR, prefix='QR')
-

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -1,16 +1,25 @@
 # -*- encoding: utf-8 -*-
-#file test_moneyed_classes.py
-from __future__ import division
-from __future__ import unicode_literals
 
+from __future__ import division, unicode_literals
+
+import warnings
 from copy import deepcopy
 from decimal import Decimal
-import warnings
 
 import pytest  # Works with less code, more consistency than unittest.
 
-from moneyed.classes import Currency, Money, MoneyComparisonError, CURRENCIES, DEFAULT_CURRENCY, USD, get_currency
+from moneyed.classes import (CURRENCIES, DEFAULT_CURRENCY, PYTHON2, USD,
+                             Currency, Money, MoneyComparisonError,
+                             force_decimal, get_currency)
 from moneyed.localization import format_money
+
+
+class CustomDecimal(Decimal):
+    """Test class to ensure Decimal.__str__ is not
+    used in calculations.
+    """
+    def __str__(self):
+        return 'error'
 
 
 class TestCurrency:
@@ -48,6 +57,9 @@ class TestCurrency:
     def test_repr(self):
         assert str(self.default_curr) == self.default_curr_code
 
+    def test_hash(self):
+        assert self.default_curr in set([self.default_curr])
+
     def test_compare(self):
         other = deepcopy(self.default_curr)
         # equality
@@ -57,8 +69,7 @@ class TestCurrency:
         other.code = 'USD'
         assert self.default_curr != other
         assert self.default_curr != CURRENCIES['USD']
-
-        #compare to string code
+        # comapre to string code
         assert self.default_curr == 'XYZ'
         assert self.default_curr != 'USD'
 
@@ -106,20 +117,32 @@ class TestMoney:
         assert one_million_dollars.amount == self.one_million_decimal
 
     def test_repr(self):
-        assert repr(self.one_million_bucks) == '1000000 USD'
-        assert repr(Money(Decimal('2.000'), 'PLN')) == '2 PLN'
-        m_1 = Money(Decimal('2.000'), 'PLN')
-        m_2 = Money(Decimal('2.000000'), 'PLN')
-        assert repr(m_1) == repr(m_2)
+        assert repr(self.one_million_bucks) == '<Money: 1000000 USD>'
+        assert repr(Money(Decimal('2.000'), 'PLN')) == '<Money: 2.000 PLN>'
+        m_1 = Money(Decimal('2.00'), 'PLN')
+        m_2 = Money(Decimal('2.01'), 'PLN')
+        assert repr(m_1) != repr(m_2)
 
     def test_str(self):
         assert str(self.one_million_bucks) == 'US$1,000,000.00'
+        one_million_pln = Money('1000000', 'PLN')
+        # if PYTHON2:
+        #     assert str(one_million_pln) == 'PLN1,000,000.00'
+        #     assert str(self.one_million_bucks) == 'USD1,000,000.00'
+        # else:
+        #     assert str(one_million_pln) == '1,000,000.00 zł'
+        #     assert str(self.one_million_bucks) == 'US$1,000,000.00'
+
+    def test_hash(self):
+        assert self.one_million_bucks in set([self.one_million_bucks])
 
     def test_format_money(self):
         # Two decimal places by default
         assert format_money(self.one_million_bucks) == 'US$1,000,000.00'
         # No decimal point without fractional part
         assert format_money(self.one_million_bucks, decimal_places=0) == 'US$1,000,000'
+        # Locale format not included, should fallback to DEFAULT
+        assert format_money(self.one_million_bucks, locale='es_ES') == 'US$1,000,000.00'
         # locale == pl_PL
         one_million_pln = Money('1000000', 'PLN')
         # Two decimal places by default
@@ -129,9 +152,24 @@ class TestMoney:
         assert format_money(one_million_pln, locale='pl_PL',
                             decimal_places=0) == '1 000 000 zł'
 
+    def test_format_money_fr(self):
+        # locale == fr_FR
+        one_million_eur = Money('1000000', 'EUR')
+        one_million_cad = Money('1000000', 'CAD')
+        assert format_money(one_million_eur, locale='fr_FR') == '1 000 000,00 €'
+        assert format_money(self.one_million_bucks, locale='fr_FR') == '1 000 000,00 $ US'
+        assert format_money(one_million_cad, locale='fr_FR') == '1 000 000,00 $ CA'
+        # No decimal point without fractional part
+        assert format_money(one_million_eur, locale='fr_FR',
+                            decimal_places=0) == '1 000 000 €'
+        # locale == fr_CA
+        assert format_money(one_million_cad, locale='fr_CA') == '1 000 000,00 $'
+        assert format_money(self.one_million_bucks, locale='fr_CA') == '1 000 000,00 $ US'
+        assert format_money(one_million_eur, locale='fr_CA') == '1 000 000,00 €'
+
     def test_add(self):
-        assert (self.one_million_bucks + self.one_million_bucks
-                == Money(amount='2000000', currency=self.USD))
+        assert (self.one_million_bucks + self.one_million_bucks ==
+                Money(amount='2000000', currency=self.USD))
 
     def test_add_non_money(self):
         with pytest.raises(TypeError):
@@ -195,8 +233,7 @@ class TestMoney:
 
     def test_rmod_bad(self):
         with pytest.raises(TypeError):
-            assert (self.one_million_bucks % self.one_million_bucks
-                    == 1)
+            assert (self.one_million_bucks % self.one_million_bucks == 1)
 
     def test_hash(self):
         instance1 = Money(amount=10, currency=self.USD)
@@ -210,7 +247,8 @@ class TestMoney:
         with warnings.catch_warnings(record=True) as warning_list:
             warnings.simplefilter("always")
             2.0 % Money(amount="10")
-            assert "Calculating percentages of Money instances using floats is deprecated" in [w.message.args[0] for w in warning_list]
+            assert ("Calculating percentages of Money instances using floats is deprecated"
+                    in [w.message.args[0] for w in warning_list])
 
     def test_convert_to_default(self):
         # Currency conversions are not implemented as of 2/2011; when
@@ -227,7 +265,7 @@ class TestMoney:
 
     def test_equality_to_other_types(self):
         x = Money(amount=0, currency=self.USD)
-        assert x != None
+        assert x != None  # NOQA
         assert x != {}
 
     def test_not_equal_to_decimal_types(self):
@@ -256,7 +294,7 @@ class TestMoney:
         x = Money(amount=-1, currency=self.USD)
         assert abs(x) == abs_money
         y = Money(amount=1, currency=self.USD)
-        assert abs(x) == abs_money
+        assert abs(y) == abs_money
 
     def test_sum(self):
         assert (sum([Money(amount=1, currency=self.USD),
@@ -300,6 +338,27 @@ class TestMoney:
         extended_money.do_my_behaviour()
         # throws error if `__mul__` doesn't return subclass instance
         (1 * extended_money).do_my_behaviour()
+
+    def test_bool(self):
+        assert bool(Money(amount=1, currency=self.USD))
+        assert not bool(Money(amount=0, currency=self.USD))
+
+    def test_force_decimal(self):
+        assert force_decimal('53.55') == Decimal('53.55')
+        assert force_decimal(53) == Decimal('53')
+        assert force_decimal(Decimal('53.55')) == Decimal('53.55')
+
+    def test_decimal_doesnt_use_str_when_multiplying(self):
+        m = Money('531', 'GBP')
+        a = CustomDecimal('53.313')
+        result = m * a
+        assert result == Money('28309.203', 'GBP')
+
+    def test_decimal_doesnt_use_str_when_dividing(self):
+        m = Money('15.60', 'GBP')
+        a = CustomDecimal('3.2')
+        result = m / a
+        assert result == Money('4.875', 'GBP')
 
 
 class ExtendedMoney(Money):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+#ignore = E123,E128,E731
+max-line-length = 119

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,27 @@
-from setuptools import setup, find_packages
+#!/usr/bin/env python
+
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
 import sys
+
 
 class Tox(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = []
         self.test_suite = True
+
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import tox
         errno = tox.cmdline(self.test_args)
         sys.exit(errno)
 
+
 setup(
     name='py-moneyed',
     packages=['moneyed'],
-    version='0.5.0',
+    version='0.7.0',
     description='Provides Currency and Money classes for use in your Python code.',
     author='Kai',
     author_email='k@limist.com',
@@ -27,7 +32,12 @@ setup(
     install_requires=[],
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Development Status :: 3 - Alpha',
@@ -44,4 +54,4 @@ setup(
     tests_require=['tox>=1.6.0', 'pytest>=2.3.0'],
     cmdclass={'test': Tox},
     include_package_data=True,
-    )
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,17 @@
 [tox]
-envlist = py26,py27,py32,py33,pypy
+# Add to .travis.yml when you add to this
+envlist = py26,py27,py32,py33,py34,py35,py36,pypy,flake,checkmanifest
 
 [testenv]
 deps=
-	pytest
+	# pytest >= 3 drops Python 3.2 support
+	pytest<3
 commands = py.test
+
+[testenv:flake]
+deps = flake8==3.2.1
+commands = flake8
+
+[testenv:checkmanifest]
+deps = check-manifest
+commands = check-manifest


### PR DESCRIPTION
…elease of .7
The change is required because django-money needs to be upgraded to the latest version because it's compatible with django 1.11. As a result, py-moneyed has to be the latest 0.7 version. Consequently, this repo needs to be update.